### PR TITLE
Add description for invitation code expiration

### DIFF
--- a/inc/plugins/doinviteonly.php
+++ b/inc/plugins/doinviteonly.php
@@ -127,6 +127,7 @@ function doinviteonly_activate()
 		'sid' => '0',
 		'name' => 'doinviteonly_expiration',
 		'title' => 'Invitaion Code Expiration',
+		'description' => 'When will invitation code expire',
 		'optionscode' => 'select\n0=Never Expire\n1=1 Day\n3=3 Days\n5=5 Days\n7=7 Days\n30=1 Month',
 		'value' => '0',
 		'disporder' => 2,


### PR DESCRIPTION
fix for


Fatal error: Uncaught mysqli_sql_exception: Field 'description' doesn't have a default value in /var/www/html/inc/db_mysqli.php:335 Stack trace: #0 /var/www/html/inc/db_mysqli.php(335): mysqli_query(Object(mysqli), '\n\t\t\tINSERT\n\t\t\tI...') #1 /var/www/html/inc/db_mysqli.php(378): DB_MySQLi->query('\n\t\t\tINSERT\n\t\t\tI...', 0, 1) #2 /var/www/html/inc/db_mysqli.php(839): DB_MySQLi->write_query('\n\t\t\tINSERT\n\t\t\tI...') #3 /var/www/html/inc/plugins/doinviteonly.php(138): DB_MySQLi->insert_query('settings', Array) #4 /var/www/html/admin/modules/config/plugins.php(439): doinviteonly_activate() #5 /var/www/html/admin/index.php(834): require('/var/www/html/a...') #6 {main} thrown in /var/www/html/inc/db_mysqli.php on line 335